### PR TITLE
Fix fast evaluator z>3 behavior with explicit out-of-range policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ If you are calling py-SP(k) in a tight loop (e.g., an MCMC likelihood) and you t
 `errors=False`, you can build a fast evaluator. This avoids per-call Pydantic validation and
 caches the k-grid and fitting-limit interpolators.
 
+By default, the evaluator enforces the same calibrated redshift ceiling as `sup_model` and
+raises for `z > 3`.
+
     import pyspk
 
     evaluator = pyspk.build_sup_model_evaluator(
@@ -209,6 +212,19 @@ caches the k-grid and fitting-limit interpolators.
 
     # In your MCMC loop:
     k, sup = evaluator(z=z, alpha=alpha, beta=beta, gamma=gamma, cosmo=cosmo)
+
+For MCMC proposals that may wander outside the calibrated range, you can opt into
+`z_out_of_range="nan"` and map invalid points to `-np.inf` in your likelihood:
+
+This rejects only that proposal (log-probability = -inf); the chain continues.
+
+    evaluator = pyspk.build_sup_model_evaluator(
+        SO=500,
+        relation_kind="cosmo_power_law",
+        k_max=8,
+        n=100,
+        z_out_of_range="nan",
+    )
 
 For cosmology-based relations, you may also pass `efunc` directly (a callable returning $E(z)$)
 instead of an `astropy` cosmology object.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyspk"
-version = "2.0.0"
+version = "2.0.1"
 description = "Python package to predict the suppression of the total matter power spectrum due to baryonic physics"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
   "ruff>=0.6",
   "black>=24",
   "mypy>=1.8",
+  "setuptools>=69",
 ]
 
 [tool.setuptools]

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,4 @@ This file exists only for older tooling that still imports `setup.py`.
 
 from setuptools import setup
 
-
 setup()

--- a/src/pyspk/__init__.py
+++ b/src/pyspk/__init__.py
@@ -21,4 +21,4 @@ __all__ = [
     "sup_model",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/src/pyspk/model.py
+++ b/src/pyspk/model.py
@@ -26,6 +26,7 @@ from typing_extensions import TypeAlias
 
 from .constants import (
     CALIBRATED_K_MAX,
+    CALIBRATED_Z_MAX,
     CALIBRATED_Z_MIN,
     K_NYQUIST,
 )
@@ -768,6 +769,7 @@ class SupModelEvaluator:
     inter_max_x0: _Akima1DInterpolator
     inter_max_x1: _Akima1DInterpolator
     inter_max_x2: _Akima1DInterpolator
+    z_out_of_range: Literal["raise", "nan"] = "raise"
 
     def __call__(
         self,
@@ -807,13 +809,36 @@ class SupModelEvaluator:
             efunc: Optional direct callable for `E(z)`; if provided, `cosmo` is not used.
             verbose: Whether to emit informational warnings.
 
+        Notes:
+            The redshift behavior for values above the calibrated range is controlled by
+            `z_out_of_range` set when building the evaluator:
+
+            - `"raise"` (default): raises `InputValidationError` for `z > 3`.
+            - `"nan"`: returns an all-NaN suppression vector for `z > 3`.
+
         Returns:
             Tuple `(k, sup)`.
 
         Raises:
             InputValidationError: If required parameters are missing for the selected relation kind.
         """
-        if z < CALIBRATED_Z_MIN:
+        zf = float(z)
+        if not _np.isfinite(zf) or zf < 0:
+            raise InputValidationError("z must be finite and >= 0")
+        if zf > CALIBRATED_Z_MAX:
+            if self.z_out_of_range == "nan":
+                if verbose:
+                    _warnings.warn(
+                        (
+                            f"Received z={zf:.3f} > calibrated maximum z={CALIBRATED_Z_MAX}. "
+                            "Returning NaNs because z_out_of_range='nan'."
+                        ),
+                        stacklevel=2,
+                    )
+                return self.k, _np.full_like(self.k, _np.nan, dtype=float)
+            raise InputValidationError(f"z must be <= {CALIBRATED_Z_MAX}")
+
+        if zf < CALIBRATED_Z_MIN:
             _warnings.warn(
                 (
                     f"pyspk was calibrated down to z = {CALIBRATED_Z_MIN}. "
@@ -823,7 +848,7 @@ class SupModelEvaluator:
                 stacklevel=2,
             )
 
-        params = _get_params(self.SO, float(z))
+        params = _get_params(self.SO, zf)
         best_mass = _optimal_mass_funct(self.k, params)
 
         if self.relation_kind == "power_law":
@@ -879,7 +904,7 @@ class SupModelEvaluator:
             m_pivot_f = float(m_pivot)
 
             efunc_callable = _resolve_efunc(cosmo=cosmo, efunc=efunc)
-            A = 0.5 * epsilon_f * _np.power(efunc_callable(z) / efunc_callable(0.3), gamma_f)
+            A = 0.5 * epsilon_f * _np.power(efunc_callable(zf) / efunc_callable(0.3), gamma_f)
             B = _np.power(10**best_mass / m_pivot_f, alpha_f)
             C = _np.power(10**best_mass / m_pivot_f, beta_f)
             f_b = A * (B + C)
@@ -911,11 +936,11 @@ class SupModelEvaluator:
             efunc_callable = _resolve_efunc(cosmo=cosmo, efunc=efunc)
             A = _np.exp(alpha_f) / 100
             B = _np.power(10**best_mass / 1e14, beta_f - 1)
-            C = _np.power(efunc_callable(z) / efunc_callable(0.3), gamma_f)
+            C = _np.power(efunc_callable(zf) / efunc_callable(0.3), gamma_f)
             f_b = A * B * C
 
         min_fb, max_fb = _get_limits_fast(
-            z=float(z),
+            z=zf,
             m_halo=10**best_mass,
             inter_min_x0=self.inter_min_x0,
             inter_min_x1=self.inter_min_x1,
@@ -946,6 +971,7 @@ def build_sup_model_evaluator(
     k_min: float = 0.1,
     k_max: float = 8,
     n: int = 100,
+    z_out_of_range: Literal["raise", "nan"] = "raise",
 ) -> SupModelEvaluator:
     """Build a fast SP(k) evaluator for repeated calls.
 
@@ -956,6 +982,10 @@ def build_sup_model_evaluator(
         k_min: Minimum k in [h/Mpc] for generated grid.
         k_max: Maximum k in [h/Mpc] for generated grid.
         n: Number of log-spaced k samples.
+        z_out_of_range:
+            Behavior for `z > 3` in evaluator calls. Use `"raise"` (default) for strict
+            consistency with `sup_model`, or `"nan"` for MCMC-style workflows that map invalid
+            proposals to non-finite likelihoods.
 
     Returns:
         A callable `SupModelEvaluator` instance.
@@ -1005,4 +1035,5 @@ def build_sup_model_evaluator(
         inter_max_x0=inter_max_x0,
         inter_max_x1=inter_max_x1,
         inter_max_x2=inter_max_x2,
+        z_out_of_range=z_out_of_range,
     )

--- a/src/pyspk/model.py
+++ b/src/pyspk/model.py
@@ -820,7 +820,8 @@ class SupModelEvaluator:
             Tuple `(k, sup)`.
 
         Raises:
-            InputValidationError: If required parameters are missing for the selected relation kind.
+            InputValidationError: If required relation parameters are missing, or if `z` is
+                invalid (`z < 0`, non-finite, or `z > 3` when `z_out_of_range="raise"`).
         """
         zf = float(z)
         if not _np.isfinite(zf) or zf < 0:
@@ -992,6 +993,8 @@ def build_sup_model_evaluator(
     """
     if SO not in (200, 500):
         raise InputValidationError("SO must be 200 or 500.")
+    if z_out_of_range not in ("raise", "nan"):
+        raise InputValidationError("z_out_of_range must be either 'raise' or 'nan'.")
 
     if k_array is not None:
         k = _np.asarray(k_array, dtype=float)

--- a/tests/test_sup_model.py
+++ b/tests/test_sup_model.py
@@ -112,3 +112,27 @@ def test_evaluator_matches_sup_model_cosmo_power_law() -> None:
 
     assert np.allclose(k1, k2)
     assert np.allclose(sup1, sup2, equal_nan=True)
+
+
+def test_evaluator_raises_for_z_above_calibrated_max() -> None:
+    """Fast evaluator defaults to strict z validation (z <= 3)."""
+    evaluator = pyspk.build_sup_model_evaluator(SO=200, relation_kind="power_law", k_max=2.0, n=32)
+
+    with pytest.raises(InputValidationError, match=r"z must be <= 3\.0"):
+        evaluator(z=3.1, fb_a=0.5, fb_pow=0.2, fb_pivot=10**13.5)
+
+
+def test_evaluator_nan_policy_for_z_above_calibrated_max() -> None:
+    """Optional NaN policy returns finite k and NaN suppression for z > 3."""
+    evaluator = pyspk.build_sup_model_evaluator(
+        SO=200,
+        relation_kind="power_law",
+        k_max=2.0,
+        n=32,
+        z_out_of_range="nan",
+    )
+
+    k, sup = evaluator(z=3.1, fb_a=0.5, fb_pow=0.2, fb_pivot=10**13.5)
+
+    assert np.all(np.isfinite(k))
+    assert np.isnan(sup).all()

--- a/tests/test_sup_model.py
+++ b/tests/test_sup_model.py
@@ -136,3 +136,15 @@ def test_evaluator_nan_policy_for_z_above_calibrated_max() -> None:
 
     assert np.all(np.isfinite(k))
     assert np.isnan(sup).all()
+
+
+def test_build_evaluator_rejects_invalid_z_out_of_range_policy() -> None:
+    """Builder validates z_out_of_range at runtime."""
+    with pytest.raises(InputValidationError, match="z_out_of_range"):
+        pyspk.build_sup_model_evaluator(
+            SO=200,
+            relation_kind="power_law",
+            k_max=2.0,
+            n=32,
+            z_out_of_range="invalid",  # type: ignore[arg-type]
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -3629,7 +3629,7 @@ wheels = [
 
 [[package]]
 name = "pyspk"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },

--- a/uv.lock
+++ b/uv.lock
@@ -3656,6 +3656,7 @@ dev = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "ruff" },
+    { name = "setuptools" },
 ]
 examples = [
     { name = "astropy", version = "5.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -3689,6 +3690,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "scipy", specifier = ">=1.8" },
+    { name = "setuptools", marker = "extra == 'dev'", specifier = ">=69" },
     { name = "typing-extensions", specifier = ">=4.8" },
 ]
 provides-extras = ["cosmology", "examples", "dev"]


### PR DESCRIPTION
## Summary
This PR fixes an inconsistency where `sup_model` rejected `z > 3` but `SupModelEvaluator` could still evaluate out-of-calibration redshifts.

## Changes
- Add `z_out_of_range` policy to `build_sup_model_evaluator`/`SupModelEvaluator`:
  - `"raise"` (default): strict parity with `sup_model` (`z <= 3` enforced)
  - `"nan"`: return all-NaN suppression for `z > 3` (MCMC-friendly)
- Keep lower-bound warning behavior for `z < 0.125`.
- Add regression tests for both `z > 3` behaviors.
- Update README MCMC section to document policy and proposal rejection semantics.
- Bump package version to `2.0.1` (`pyproject.toml`, `__init__.py`, `uv.lock`).

## Why
- Preserves calibrated-physics safety by default.
- Supports robust sampler workflows where invalid proposals should be rejected without raising.

## Validation
- Local tests: `7 passed` via `python -m pytest -q` in `.venv`.